### PR TITLE
fix(preview-deploy): skip cleanly when GCP set but NEON_API_KEY missing

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -36,28 +36,55 @@ jobs:
         # gates can read. `auth_method` selects between WIF (keyless,
         # recommended) and SA key (workshop shortcut). `neon_configured`
         # gates the per-PR Neon-branch creation step.
+        #
+        # The deploy requires BOTH GCP auth and Neon. If either is
+        # missing we set skip=true and surface an actionable message in
+        # the PR check summary, instead of attempting a deploy that's
+        # guaranteed to fail. Half-configured state (GCP set, Neon
+        # missing) was the cause of PR #35's first preview failure: the
+        # container booted with no DATABASE_URL, app/config.py refused
+        # SQLite in environment=preview, and Cloud Run reported an
+        # opaque "container failed to start" timeout 80 seconds later.
         run: |
+          # 1) Pick auth_method. "none" means we have no usable GCP creds.
           if [ -z "${{ secrets.GCP_PROJECT_ID }}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "auth_method=none" >> "$GITHUB_OUTPUT"
-            echo "neon_configured=false" >> "$GITHUB_OUTPUT"
-            echo "GCP_PROJECT_ID not configured — skipping preview deploy."
+            AUTH_METHOD="none"
+            SKIP_REASON="GCP_PROJECT_ID not configured"
           elif [ -n "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "auth_method=wif" >> "$GITHUB_OUTPUT"
+            AUTH_METHOD="wif"
           elif [ -n "${{ secrets.GCP_SA_KEY }}" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "auth_method=sa-key" >> "$GITHUB_OUTPUT"
+            AUTH_METHOD="sa-key"
           else
+            AUTH_METHOD="none"
+            SKIP_REASON="GCP_PROJECT_ID set but no auth secret (need GCP_WORKLOAD_IDENTITY_PROVIDER or GCP_SA_KEY)"
+          fi
+
+          # 2) Determine Neon presence (independent of GCP).
+          if [ -n "${{ secrets.NEON_API_KEY }}" ]; then
+            NEON_CONFIGURED="true"
+          else
+            NEON_CONFIGURED="false"
+          fi
+
+          # 3) Decide whether to deploy. We require BOTH GCP auth and
+          # Neon — without DATABASE_URL the container fails its readiness
+          # probe because app/config.py refuses SQLite in non-dev
+          # environments. Skipping cleanly with an actionable warning is
+          # strictly better than a 1m20s opaque container-start timeout.
+          if [ "$AUTH_METHOD" = "none" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
+            echo "neon_configured=$NEON_CONFIGURED" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Preview deploy skipped::${SKIP_REASON}"
+          elif [ "$NEON_CONFIGURED" = "false" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "auth_method=none" >> "$GITHUB_OUTPUT"
             echo "neon_configured=false" >> "$GITHUB_OUTPUT"
-            echo "No GCP auth configured — skipping preview deploy."
-          fi
-          if [ -n "${{ secrets.NEON_API_KEY }}" ]; then
-            echo "neon_configured=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Preview deploy skipped — Neon not configured::GCP secrets are set but NEON_API_KEY is missing. Without it the per-PR Neon branch step is skipped, no DATABASE_URL is passed to Cloud Run, and the container fails its readiness probe (app/config.py refuses SQLite in non-dev environments). Set the secret with: gh secret set NEON_API_KEY --repo \$GITHUB_REPOSITORY"
           else
-            echo "neon_configured=false" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=$AUTH_METHOD" >> "$GITHUB_OUTPUT"
+            echo "neon_configured=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout code


### PR DESCRIPTION
## Quick fix — no linked ticket

Follow-up flagged in PR #37's body. Hardens the workflow so the failure mode that bit PR #35 the first time around (1m20s opaque container-start timeout) becomes a 5-second clean skip with an actionable message.

## Behavior change

Failure mode before this PR:

| GCP_PROJECT_ID | GCP auth | NEON_API_KEY | Old behavior | New behavior |
|---|---|---|---|---|
| ✗ | – | – | skip with notice | skip with notice (same) |
| ✓ | ✗ | – | skip with notice | skip with notice (same) |
| ✓ | ✓ | ✗ | **deploy, container fails to start, opaque 80s timeout** | **skip with `::warning::` annotation explaining the missing secret + fix command** |
| ✓ | ✓ | ✓ | deploy proceeds | deploy proceeds (unchanged) |

## Why

PR #35's first preview attempt hit row 3. The Neon-branch step is gated on `neon_configured == 'true'`, so it silently skipped. No `DATABASE_URL` was added to the Cloud Run env. The container booted, `app/config.py::Settings._refuse_sqlite_outside_dev` correctly raised `ValueError(\"DATABASE_URL is SQLite in preview\")`, and Cloud Run reported a generic \"container failed to start and listen on the port\" with no hint that a missing secret was the root cause. The signal was 80 seconds late and pointed in the wrong direction.

By requiring BOTH GCP auth and Neon for `skip != 'true'`, the workflow now fails fast at the gate with:

```
::warning title=Preview deploy skipped — Neon not configured::
GCP secrets are set but NEON_API_KEY is missing.
Without it the per-PR Neon branch step is skipped, no DATABASE_URL is
passed to Cloud Run, and the container fails its readiness probe
(app/config.py refuses SQLite in non-dev environments).
Set the secret with: gh secret set NEON_API_KEY --repo \$GITHUB_REPOSITORY
```

GitHub Actions surfaces `::warning::` annotations in the PR check summary, so the next person who hits this state sees the fix command without having to read the workflow source.

## What's NOT changing

- The fully-configured path (this repo, post-NEON_API_KEY-set) is identical to before: `skip=false, auth_method=wif, neon_configured=true`. This PR's own preview deploy will exercise it.
- Downstream `if:` gates that read `skip`, `auth_method`, and `neon_configured` are unchanged — the new logic produces the same set of output values, just with stricter rules for emitting them.
- No app code, no test code, no other workflows touched.

## Verification

- `python -c \"yaml.safe_load(open(...))\"` — parses cleanly
- `actionlint` runs in CI; will validate
- This PR's preview deploy passing end-to-end is the integration test for the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)