### PR TITLE
fix(auth): build verify_url from request, wire RESEND_API_KEY into deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,6 +160,7 @@ jobs:
           env_vars: |
             ENVIRONMENT=production
             DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
+            RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
 
       - name: Route traffic to latest revision
         # success() gates on all prior steps succeeding — without it,

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -205,6 +205,12 @@ jobs:
           if [ -n "${{ steps.neon.outputs.db_url_with_pooler }}" ]; then
             ENV_VARS="${ENV_VARS};DATABASE_URL=${{ steps.neon.outputs.db_url_with_pooler }}"
           fi
+          # RESEND_API_KEY is opt-in: if the secret is unset the preview
+          # boots without it and any code path that calls Resend will fail
+          # at request time rather than at container start.
+          if [ -n "${{ secrets.RESEND_API_KEY }}" ]; then
+            ENV_VARS="${ENV_VARS};RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}"
+          fi
 
           # --service-account pins the runtime SA to the deployer SA so
           # the revision can read mounted Secret Manager secrets and any

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -20,6 +20,8 @@ from app.models.auth import MagicLinkToken
 from app.services.email import send_magic_link
 from app.templates import templates
 
+VERIFY_PATH = "/auth/verify"
+
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 SessionDep = Annotated[Session, Depends(get_session)]
@@ -52,7 +54,13 @@ async def login_submit(
     )
     session.commit()
 
-    verify_url = f"{settings.app_url.rstrip('/')}/auth/verify?token={raw_token}"
+    # Build the verify URL from the incoming request so previews, prod,
+    # and local dev all produce a link that points back to their own
+    # origin. ProxyHeadersMiddleware (registered in app.main) rewrites
+    # request.url.scheme from X-Forwarded-Proto; request.url.hostname
+    # comes from the Host header, which Cloud Run already sets to the
+    # external hostname before forwarding to the container.
+    verify_url = str(request.url.replace(path=VERIFY_PATH, query=f"token={raw_token}"))
     await send_magic_link(to=email, verify_url=verify_url)
 
     return templates.TemplateResponse(request, "auth/check_email.html")

--- a/app/config.py
+++ b/app/config.py
@@ -16,7 +16,6 @@ class Settings(BaseSettings):
     """App settings loaded from environment variables."""
 
     database_url: str = "sqlite:///./dev.db"
-    app_url: str = "http://localhost:8080"
     environment: str = "development"
     resend_api_key: str = ""
     resend_from_email: str = "noreply@croissantfella.dev"

--- a/app/main.py
+++ b/app/main.py
@@ -11,12 +11,19 @@ from pathlib import Path
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from app.api import health
 from app.auth import routes as auth_routes
 from app.templates import templates
 
 app = FastAPI(title="Croissantfella")
+# Cloud Run terminates TLS at the proxy and forwards via X-Forwarded-Proto
+# and X-Forwarded-Host. Without this middleware, request.url returns the
+# internal Cloud Run origin (http://localhost:8080) and absolute URLs
+# constructed from it (magic links, OAuth redirects) silently break in
+# preview and production. See docs/PATTERN-LIBRARY.md pitfall #3.
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
 STATIC_DIR = Path(__file__).parent.parent / "static"
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -86,6 +86,35 @@ def test_post_login_persists_hashed_token_with_15min_ttl(
     assert expected_min <= expires_at <= expected_max
 
 
+def test_post_login_verify_url_uses_forwarded_proto_and_host_header(
+    client: TestClient, session: Session
+) -> None:
+    """Magic-link URL points back to the preview's own origin.
+
+    Cloud Run terminates TLS at GFE, then forwards to the container with
+    Host set to the external hostname (pr-N---svc-hash.run.app for tagged
+    previews) and X-Forwarded-Proto=https. ProxyHeadersMiddleware rewrites
+    request.url.scheme from X-Forwarded-Proto; request.url.hostname comes
+    straight from the Host header, which is already the external value.
+    """
+    with respx.mock() as mock:
+        route = mock.post(RESEND_ENDPOINT).mock(return_value=RESEND_OK)
+        response = client.post(
+            "/auth/login",
+            data={"email": "alice@example.com"},
+            headers={
+                "Host": "pr-99---app-abc123-uc.a.run.app",
+                "X-Forwarded-Proto": "https",
+            },
+        )
+
+    assert response.status_code == 200
+    body = route.calls.last.request.content.decode("utf-8")
+    assert "https://pr-99---app-abc123-uc.a.run.app/auth/verify?token=" in body
+    assert "testserver" not in body  # the default TestClient host MUST NOT leak
+    assert "http://" not in body  # scheme MUST be the forwarded https
+
+
 def test_post_login_calls_resend_with_url_containing_raw_token(
     client: TestClient, session: Session
 ) -> None:


### PR DESCRIPTION
**Quick fix — no linked ticket.** Addresses the load-bearing follow-up flagged by the independent reviewer on PR #41 (see [#41 review comment](https://github.com/vibeacademy/croissantfella/pull/41#issuecomment-4423243673), item 2 of the Suggestions section) before the next auth ticket (GET /auth/verify) ships.

## Why this needs to land before /auth/verify

The magic-link email sent by `POST /auth/login` (PR #41) embeds a `verify_url`. Before this PR that URL was built from `settings.app_url`, which defaults to `http://localhost:8080`. Neither `APP_URL` nor `RESEND_API_KEY` was set in `deploy.yml` or `preview-deploy.yml`, so any link clicked from a preview email would point at the user's localhost — silently broken in a way that looks like an auth bug.

## What changed

**Application:**
- `app/main.py` — register `ProxyHeadersMiddleware(trusted_hosts="*")` so `request.url.scheme` reflects Cloud Run's `X-Forwarded-Proto` instead of the internal `http://`. The Host header is already the external hostname (Cloud Run sets it before forwarding), so `request.url.hostname` is correct without extra wiring. See `docs/PATTERN-LIBRARY.md` pitfall #3.
- `app/auth/routes.py` — construct `verify_url` from `request.url.replace(path=VERIFY_PATH, query=...)` instead of `f"{settings.app_url}..."`. Works in prod, every preview, and local dev with no chicken-and-egg in setting the env var before deploy.
- `app/config.py` — remove the now-unused `app_url` setting.

**Workflows:**
- `.github/workflows/deploy.yml` — add `RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}` to the production `env_vars` block.
- `.github/workflows/preview-deploy.yml` — add `RESEND_API_KEY` to the `ENV_VARS` string, gated on the secret being set so unconfigured forks still get a working preview boot (Resend calls fail at request time rather than at container start).

**Tests:**
- `tests/auth/test_login.py::test_post_login_verify_url_uses_forwarded_proto_and_host_header` — posts to `/auth/login` with `X-Forwarded-Proto: https` and a tagged-preview-style `Host` header, asserts the link in the mocked Resend body uses both (and that `testserver` doesn't leak).

## Test results
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy app/` — clean (19 source files)
- `uv run pytest --cov=app` — **35/35 pass, 99% coverage** (up from 34/99% on PR #41)

## Why a Quick Fix, not a ticket
Configuration tweak + small route change + one test. Within the Quick Fix Protocol scope per `CLAUDE.md` (workflow config changes, < 20 lines of behavior change). PR description carries the rationale; no board move because there's no linked issue.

## Out of scope
- Adding `EmailStr` validation on the form field (item 1 from the PR #41 reviewer suggestions) — separate ticket if worth it
- Rate limiting on `POST /auth/login` (item 4) — separate ticket
- Token expiry as a per-environment override (item 5) — defer

🤖 Generated with [Claude Code](https://claude.com/claude-code)