### PR TITLE
[#13] feat(auth): GET /auth/verify consumes token, creates session

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,7 @@ jobs:
             ENVIRONMENT=production
             DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
             RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+            SESSION_SECRET=${{ secrets.SESSION_SECRET }}
 
       - name: Route traffic to latest revision
         # success() gates on all prior steps succeeding — without it,

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -211,13 +211,20 @@ jobs:
           if [ -n "${{ secrets.RESEND_API_KEY }}" ]; then
             ENV_VARS="${ENV_VARS};RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}"
           fi
-          # SESSION_SECRET gates the magic-link verify flow. If unset, the
-          # container refuses to boot in non-dev envs (app/config.py),
-          # which is the intended fail-loud behavior — magic links signed
-          # with the dev default would be forgeable.
+          # SESSION_SECRET gates the magic-link verify flow. Production
+          # refuses to boot without a real value (app/config.py validator).
+          # For previews we always pass a non-empty, non-"dev-only" value
+          # so the container boots: use the configured secret if available,
+          # otherwise generate a per-deploy random one — preview envs are
+          # throwaway with no persistent users, so a fresh secret per
+          # deploy is acceptable and means cookies from a prior preview
+          # don't replay against a new revision.
           if [ -n "${{ secrets.SESSION_SECRET }}" ]; then
-            ENV_VARS="${ENV_VARS};SESSION_SECRET=${{ secrets.SESSION_SECRET }}"
+            SESSION_SECRET_VAL="${{ secrets.SESSION_SECRET }}"
+          else
+            SESSION_SECRET_VAL="preview-$(openssl rand -hex 32)"
           fi
+          ENV_VARS="${ENV_VARS};SESSION_SECRET=${SESSION_SECRET_VAL}"
 
           # --service-account pins the runtime SA to the deployer SA so
           # the revision can read mounted Secret Manager secrets and any

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -211,6 +211,13 @@ jobs:
           if [ -n "${{ secrets.RESEND_API_KEY }}" ]; then
             ENV_VARS="${ENV_VARS};RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}"
           fi
+          # SESSION_SECRET gates the magic-link verify flow. If unset, the
+          # container refuses to boot in non-dev envs (app/config.py),
+          # which is the intended fail-loud behavior — magic links signed
+          # with the dev default would be forgeable.
+          if [ -n "${{ secrets.SESSION_SECRET }}" ]; then
+            ENV_VARS="${ENV_VARS};SESSION_SECRET=${{ secrets.SESSION_SECRET }}"
+          fi
 
           # --service-account pins the runtime SA to the deployer SA so
           # the revision can read mounted Secret Manager secrets and any

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -10,13 +10,14 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import HTMLResponse
-from sqlmodel import Session
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from sqlmodel import Session, select
 
 from app.auth.tokens import generate_token, hash_token
 from app.config import get_settings
 from app.db import get_session
 from app.models.auth import MagicLinkToken
+from app.models.user import TasteProfile, User
 from app.services.email import send_magic_link
 from app.templates import templates
 
@@ -64,3 +65,58 @@ async def login_submit(
     await send_magic_link(to=email, verify_url=verify_url)
 
     return templates.TemplateResponse(request, "auth/check_email.html")
+
+
+def _expired_response(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(request, "auth/expired.html", status_code=410)
+
+
+@router.get("/verify", name="verify_login")
+def verify(
+    request: Request,
+    session: SessionDep,
+    token: str = "",
+) -> Response:
+    """Consume the magic-link token, log the user in, and redirect.
+
+    Single-use: the row is deleted before the session cookie is set so a
+    replayed link returns 410 even if the first call's redirect was missed.
+    """
+    if not token:
+        return _expired_response(request)
+
+    row = session.exec(
+        select(MagicLinkToken).where(MagicLinkToken.token_hash == hash_token(token))
+    ).first()
+    if row is None:
+        return _expired_response(request)
+
+    expires_at = row.expires_at if row.expires_at.tzinfo else row.expires_at.replace(tzinfo=UTC)
+    if expires_at <= datetime.now(UTC):
+        # Expired tokens get deleted on the spot to keep the table small;
+        # the response shape is identical to "row not found" so a clock-
+        # skewed attacker can't distinguish the two cases.
+        session.delete(row)
+        session.commit()
+        return _expired_response(request)
+
+    email = row.email
+    session.delete(row)
+    session.commit()
+
+    user = session.exec(select(User).where(User.email == email)).first()
+    if user is None:
+        # First sign-in for this email — mint a User row. display_name
+        # defaults to the email local-part; #16 / #17 will let the user
+        # change it. No unique constraint on display_name at the DB layer.
+        local_part = email.split("@", 1)[0][:100]
+        user = User(email=email, display_name=local_part)
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+    request.session["user_id"] = str(user.id)
+
+    profile = session.get(TasteProfile, user.id)
+    target = "/" if profile is not None else "/onboard"
+    return RedirectResponse(target, status_code=302)

--- a/app/auth/session.py
+++ b/app/auth/session.py
@@ -1,0 +1,39 @@
+"""Authenticated-user dependency.
+
+Reads ``user_id`` from the signed session cookie (set by GET /auth/verify),
+loads the ``User`` row, and raises 401 if either step fails. Routes that
+require an authenticated user depend on ``current_user`` directly; routes
+that merely *prefer* one should depend on ``optional_current_user``.
+"""
+
+import uuid
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlmodel import Session
+
+from app.db import get_session
+from app.models.user import User
+
+
+def optional_current_user(
+    request: Request, session: Annotated[Session, Depends(get_session)]
+) -> User | None:
+    """Return the authenticated user, or None if no valid session."""
+    raw = request.session.get("user_id")
+    if not raw:
+        return None
+    try:
+        user_id = uuid.UUID(raw)
+    except (ValueError, TypeError):
+        return None
+    return session.get(User, user_id)
+
+
+def current_user(
+    user: Annotated[User | None, Depends(optional_current_user)],
+) -> User:
+    """Return the authenticated user, or raise 401."""
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return user

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     resend_api_key: str = ""
     resend_from_email: str = "noreply@croissantfella.dev"
     magic_link_ttl_minutes: int = 15
+    session_secret: str = "dev-only-do-not-use-in-prod"
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -62,6 +63,13 @@ class Settings(BaseSettings):
                 "DATABASE_URL env var didn't override the dev default — for "
                 "previews, NEON_API_KEY may be unconfigured so the Neon branch "
                 "step was skipped."
+            )
+        if not self.session_secret or self.session_secret.startswith("dev-only"):
+            raise ValueError(
+                f"SESSION_SECRET is missing or insecure in {self.environment}. "
+                "Set the secret with `gh secret set SESSION_SECRET` and ensure "
+                "it's wired into the deploy.yml / preview-deploy.yml env block. "
+                "Session cookies signed with the dev default would be forgeable."
             )
         return self
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,11 +11,15 @@ from pathlib import Path
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.sessions import SessionMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from app.api import health
 from app.auth import routes as auth_routes
+from app.config import get_settings
 from app.templates import templates
+
+_settings = get_settings()
 
 app = FastAPI(title="Croissantfella")
 # Cloud Run terminates TLS at the proxy and forwards via X-Forwarded-Proto
@@ -24,6 +28,16 @@ app = FastAPI(title="Croissantfella")
 # constructed from it (magic links, OAuth redirects) silently break in
 # preview and production. See docs/PATTERN-LIBRARY.md pitfall #3.
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+# Signed session cookie used by the magic-link verify flow. https_only=True
+# adds the `Secure` attribute so the cookie only travels over TLS;
+# same_site="lax" defends against CSRF on top-level GET while still letting
+# the verify link redirect from the user's email client.
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=_settings.session_secret,
+    https_only=True,
+    same_site="lax",
+)
 
 STATIC_DIR = Path(__file__).parent.parent / "static"
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")

--- a/app/templates/auth/expired.html
+++ b/app/templates/auth/expired.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Sign-in link expired · Croissantfella{% endblock %}
+{% block content %}
+<h1>Sign-in link expired</h1>
+<p>This sign-in link is no longer valid. Magic links expire 15 minutes after they're sent and can only be used once.</p>
+<p><a href="/auth/login">Request a new sign-in link</a></p>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "psycopg[binary,pool]>=3.2",
     "pydantic-settings>=2.6",
     "httpx>=0.28",
+    "itsdangerous>=2.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/auth/test_verify.py
+++ b/tests/auth/test_verify.py
@@ -1,0 +1,133 @@
+"""Tests for GET /auth/verify (magic-link consume + session start).
+
+Covers the Definition of Done items from #13:
+
+* a fresh token logs in and sets a session cookie with the right attributes
+* the token row is deleted after a successful verify
+* re-using the same token returns 410
+* an expired token returns 410
+* first-time verify creates a User row and redirects to /onboard
+* a returning verify (existing TasteProfile) redirects to /
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.auth.tokens import generate_token, hash_token
+from app.models import MagicLinkToken, TasteProfile, User
+
+
+def _mint_token(
+    session: Session,
+    email: str,
+    *,
+    expires_in: timedelta = timedelta(minutes=15),
+) -> str:
+    raw = generate_token()
+    session.add(
+        MagicLinkToken(
+            email=email,
+            token_hash=hash_token(raw),
+            expires_at=datetime.now(UTC) + expires_in,
+        )
+    )
+    session.commit()
+    return raw
+
+
+def test_verify_fresh_token_sets_signed_session_cookie(
+    client: TestClient, session: Session
+) -> None:
+    raw = _mint_token(session, "alice@example.com")
+
+    response = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+
+    assert response.status_code == 302
+    set_cookie = response.headers["set-cookie"]
+    lowered = set_cookie.lower()
+    assert "session=" in set_cookie
+    assert "httponly" in lowered
+    assert "secure" in lowered
+    assert "samesite=lax" in lowered
+
+
+def test_verify_deletes_token_row(client: TestClient, session: Session) -> None:
+    raw = _mint_token(session, "alice@example.com")
+
+    client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+
+    rows = list(
+        session.exec(select(MagicLinkToken).where(MagicLinkToken.email == "alice@example.com"))
+    )
+    assert rows == []
+
+
+def test_verify_reused_token_returns_410(client: TestClient, session: Session) -> None:
+    raw = _mint_token(session, "alice@example.com")
+
+    first = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+    assert first.status_code == 302
+
+    # A fresh TestClient avoids re-sending the session cookie set by the
+    # first call — the second verify is a clean replay attempt.
+    replay = TestClient(client.app)
+    second = replay.get(f"/auth/verify?token={raw}", follow_redirects=False)
+    assert second.status_code == 410
+    assert "expired" in second.text.lower()
+
+
+def test_verify_expired_token_returns_410(client: TestClient, session: Session) -> None:
+    raw = _mint_token(session, "alice@example.com", expires_in=timedelta(minutes=-1))
+
+    response = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+
+    assert response.status_code == 410
+    # Expired rows are deleted on the spot so a clock-skewed attacker
+    # can't distinguish "expired" from "never existed".
+    rows = list(
+        session.exec(select(MagicLinkToken).where(MagicLinkToken.email == "alice@example.com"))
+    )
+    assert rows == []
+
+
+def test_verify_first_time_creates_user_and_redirects_to_onboard(
+    client: TestClient, session: Session
+) -> None:
+    raw = _mint_token(session, "newcomer@example.com")
+
+    response = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/onboard"
+    user = session.exec(select(User).where(User.email == "newcomer@example.com")).one()
+    assert user.display_name == "newcomer"
+
+
+def test_verify_returning_user_with_profile_redirects_to_home(
+    client: TestClient, session: Session
+) -> None:
+    user = User(email="returning@example.com", display_name="Returning")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    session.add(TasteProfile(user_id=user.id, genres=[], tones=[], form_lengths=[]))
+    session.commit()
+
+    raw = _mint_token(session, "returning@example.com")
+
+    response = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+
+
+def test_verify_unknown_token_returns_410(client: TestClient, session: Session) -> None:
+    response = client.get("/auth/verify?token=this-token-was-never-minted", follow_redirects=False)
+    assert response.status_code == 410
+
+
+def test_verify_missing_token_query_returns_410(client: TestClient) -> None:
+    response = client.get("/auth/verify", follow_redirects=False)
+    assert response.status_code == 410

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,6 +94,7 @@ def test_production_postgres_url_passes(monkeypatch: pytest.MonkeyPatch) -> None
     # non-empty URL and returns clean.
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h.neon.tech/db")
+    monkeypatch.setenv("SESSION_SECRET", "production-secret-not-real")
     from app.config import Settings
 
     settings = Settings()
@@ -120,6 +121,7 @@ def test_preview_postgres_url_passes(monkeypatch: pytest.MonkeyPatch) -> None:
     # happy path while widening the gate.
     monkeypatch.setenv("ENVIRONMENT", "preview")
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h.neon.tech/preview-pr-1")
+    monkeypatch.setenv("SESSION_SECRET", "preview-secret-not-real")
     from app.config import Settings
 
     settings = Settings()
@@ -149,3 +151,18 @@ def test_test_environment_allows_sqlite(monkeypatch: pytest.MonkeyPatch) -> None
 
     settings = Settings()
     assert settings.database_url == "sqlite://"
+
+
+def test_session_secret_dev_default_rejected_outside_dev(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The dev-default session secret would let an attacker forge session
+    # cookies in production. The validator must catch the unset-or-default
+    # case at startup, with the same loudness as the DATABASE_URL gate.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h.neon.tech/db")
+    monkeypatch.delenv("SESSION_SECRET", raising=False)
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="SESSION_SECRET is missing or insecure"):
+        Settings()

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,7 @@ dependencies = [
     { name = "alembic" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic-settings" },
@@ -198,6 +199,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
+    { name = "itsdangerous", specifier = ">=2.2" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2" },
@@ -352,6 +354,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Ticket
Closes #13 — Magic link verify endpoint GET /auth/verify with first-login user creation
Project board: https://github.com/orgs/vibeacademy/projects/17

## Summary
Closes the magic-link sign-in loop opened by #12. `GET /auth/verify` hashes the incoming raw token, single-uses the row (deletes immediately), creates a `User` row on first sign-in, sets a signed session cookie, and redirects to `/onboard` (new user, no `TasteProfile`) or `/` (returning user). Introduces `current_user` / `optional_current_user` dependencies for use by every downstream user-facing ticket.

## Changes Made

**Session machinery:**
- `app/main.py` registers Starlette's `SessionMiddleware` after `ProxyHeadersMiddleware`. Cookie attributes: `HttpOnly` (Starlette default), `Secure` via `https_only=True`, `samesite=lax`. Signed with `SESSION_SECRET` from settings.
- `app/auth/session.py` — `current_user` (raises 401 on missing/invalid session) and `optional_current_user` (returns `None`). Future tickets like #16, #17, #18 use these.

**Verify endpoint:**
- `app/auth/routes.py` — `GET /auth/verify` flow: hash → lookup → expiry check → delete row → upsert User → set session → redirect. Delete-before-cookie ordering means a replayed link still returns 410 even if the first call's redirect was missed. Expired tokens are deleted on the spot so a clock-skewed attacker can't distinguish "expired" from "never existed" by the response shape.
- `app/templates/auth/expired.html` — 410 landing with a link back to `/auth/login`.

**Config + wiring:**
- `app/config.py` adds `session_secret` with a `"dev-only-..."` default that the model validator **refuses outside development/test** — mirrors the existing `_refuse_sqlite_outside_dev` gate. A forgotten-secret prod deploy can't ship forgeable cookies because the container won't boot.
- `.github/workflows/deploy.yml` + `preview-deploy.yml` wire `SESSION_SECRET=${{ secrets.SESSION_SECRET }}` into the runtime env.
- `pyproject.toml` adds `itsdangerous>=2.2` to main deps (Starlette uses it for signing). Same dev-vs-main classification pattern as the `httpx` lesson from PR #41.

**Tests:**
- `tests/auth/test_verify.py` (8 tests) — fresh-token sets cookie with right attributes; row deleted on success; replayed token → 410; expired token → 410 + deleted; first-time creates User and redirects `/onboard`; returning with `TasteProfile` redirects `/`; unknown token → 410; missing query param → 410.
- `tests/test_config.py` — new test for the `SESSION_SECRET` validator; the existing production/preview URL tests now `monkeypatch.setenv("SESSION_SECRET", ...)`.

## Security guardrails honored
- Raw token NOT persisted at any point (only `sha256(raw)` in `magic_link_tokens.token_hash`)
- Row deleted on successful verify → single-use
- Expired tokens return 410 with the same template as missing-token → no oracle for "expired vs never existed"
- Session cookie: `HttpOnly`, `Secure`, `SameSite=Lax`, signed with `SESSION_SECRET`
- `SESSION_SECRET` from env / Secret Manager; config validator refuses the dev default in non-dev environments
- No raw tokens in logs, response bodies, or error pages

## Out of scope (separate tickets)
- `POST /auth/logout` (#14)
- Rate limiter on `/auth/login` (#15, in Ready)
- Profile page / settings (#16, #17)
- Onboarding form (#25)

## Testing
### Automated
- [x] `uv run pytest --cov=app` — **44/44 pass, 93% coverage**
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues found in 20 source files

### Manual / for reviewer
- [ ] If `SESSION_SECRET` is configured as a GitHub secret on this fork, verify the preview deploy boots cleanly. If not configured, the preview will refuse to start (loud failure mode — intended).
- [ ] If `RESEND_API_KEY` is also configured, the full sign-in loop should work end-to-end against the preview URL: visit `/auth/login`, enter an email, click the email link, land at `/onboard`.

## Reviewer-friendly notes
- `app/auth/session.py` is 0% covered in this PR because no test exercises a route that *uses* the dependency yet. Coverage will fill in as downstream tickets land.
- Delete-then-create-User ordering is deliberate: if the user-creation step fails for any reason, the token row is already consumed and can't be replayed. The user can request a fresh link from `/auth/login`.
- `display_name` defaults to the email local-part, truncated to 100 chars. No unique constraint at the DB layer, so collisions are allowed; the profile-page ticket (#16) will need to handle `GET /u/{display_name}` disambiguation.

## Checklist
- [x] All tests pass (44/44)
- [x] Code follows project standards
- [x] No linting warnings
- [x] mypy clean