### PR TITLE
[#15] feat(auth): in-process rate limiter for magic-link send

### DIFF
--- a/app/auth/rate_limit.py
+++ b/app/auth/rate_limit.py
@@ -1,0 +1,74 @@
+"""In-process rate limiter for magic-link sends.
+
+Fixed hour-bucket counters per key. Suitable for MVP scale (single Cloud
+Run instance, ~250 users); for multi-instance scaling, swap for Redis
+or a shared store. State is module-global and resets on process restart
+— acceptable because magic-link bursts are short-lived and a restart is
+worse for the user than a forgotten rate-limit count.
+
+Both limits are enforced inside POST /auth/login. Exceeding either limit
+suppresses the Resend call but returns the SAME response shape as a
+normal send, preserving email-enumeration safety per
+docs/AGENTIC-CONTROLS.md.
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+
+EMAIL_LIMIT_PER_HOUR = 5
+IP_LIMIT_PER_HOUR = 20
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FixedBucketRateLimiter:
+    """Atomic check-and-increment with hour buckets."""
+
+    max_per_hour: int
+    _counts: dict[tuple[str, int], int] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def consume(self, key: str) -> bool:
+        """Increment the counter for ``key`` in the current hour bucket
+        and return True if the request is allowed (counter was below the
+        limit before this call). Atomic against concurrent callers."""
+        bucket = int(time.time() // 3600)
+        bucket_key = (key, bucket)
+        with self._lock:
+            current = self._counts.get(bucket_key, 0)
+            if current >= self.max_per_hour:
+                return False
+            self._counts[bucket_key] = current + 1
+            return True
+
+    def _reset(self) -> None:
+        """Clear all buckets. Test-only — production state is reset by
+        process restart."""
+        with self._lock:
+            self._counts.clear()
+
+
+email_limiter = FixedBucketRateLimiter(max_per_hour=EMAIL_LIMIT_PER_HOUR)
+ip_limiter = FixedBucketRateLimiter(max_per_hour=IP_LIMIT_PER_HOUR)
+
+
+def check_magic_link_rate_limit(*, email: str, client_ip: str) -> bool:
+    """Consume one slot from each limiter. Returns True only if BOTH
+    limiters allow the request. Logs at INFO with the suppressed key
+    when either limit is hit."""
+    email_ok = email_limiter.consume(email.lower())
+    ip_ok = ip_limiter.consume(client_ip)
+    if not (email_ok and ip_ok):
+        logger.info(
+            "magic_link_rate_limited",
+            extra={
+                "email_limit_hit": not email_ok,
+                "ip_limit_hit": not ip_ok,
+                "client_ip": client_ip,
+            },
+        )
+        return False
+    return True

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from sqlmodel import Session, select
 
+from app.auth.rate_limit import check_magic_link_rate_limit
 from app.auth.tokens import generate_token, hash_token
 from app.config import get_settings
 from app.db import get_session
@@ -42,6 +43,14 @@ async def login_submit(
 ) -> HTMLResponse:
     """Mint a token, store its hash, send the magic link, return the
     same "check your email" page for every input."""
+    # Rate limit BEFORE any DB write or outbound HTTP call. Suppressed
+    # requests still return the same template so the response shape is
+    # identical to a successful send — an attacker can't probe whether
+    # they're being throttled.
+    client_ip = request.client.host if request.client else "unknown"
+    if not check_magic_link_rate_limit(email=email, client_ip=client_ip):
+        return templates.TemplateResponse(request, "auth/check_email.html")
+
     settings = get_settings()
     raw_token = generate_token()
     expires_at = datetime.now(UTC) + timedelta(minutes=settings.magic_link_ttl_minutes)

--- a/tests/auth/test_rate_limit.py
+++ b/tests/auth/test_rate_limit.py
@@ -1,0 +1,86 @@
+"""Tests for the magic-link rate limiter.
+
+Covers the Definition of Done items from #15:
+
+* the 6th send to the same email within an hour does NOT call Resend
+* the 21st send from the same IP within an hour does NOT call Resend
+* the response body and status are identical whether the limit was
+  hit or not (enumeration-safety preservation)
+"""
+
+import httpx
+import respx
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.auth.rate_limit import (
+    EMAIL_LIMIT_PER_HOUR,
+    IP_LIMIT_PER_HOUR,
+    FixedBucketRateLimiter,
+)
+from app.models import MagicLinkToken
+from app.services.email import RESEND_ENDPOINT
+
+RESEND_OK = httpx.Response(200, json={"id": "test_email_id"})
+
+
+def test_email_limit_blocks_sixth_send(client: TestClient, session: Session) -> None:
+    """5 sends to the same email succeed; the 6th is suppressed."""
+    with respx.mock() as mock:
+        route = mock.post(RESEND_ENDPOINT).mock(return_value=RESEND_OK)
+        for _ in range(EMAIL_LIMIT_PER_HOUR):
+            response = client.post("/auth/login", data={"email": "alice@example.com"})
+            assert response.status_code == 200
+        assert route.call_count == EMAIL_LIMIT_PER_HOUR
+
+        suppressed = client.post("/auth/login", data={"email": "alice@example.com"})
+
+    assert suppressed.status_code == 200
+    assert route.call_count == EMAIL_LIMIT_PER_HOUR  # Resend NOT called the 6th time
+
+    tokens = list(
+        session.exec(select(MagicLinkToken).where(MagicLinkToken.email == "alice@example.com"))
+    )
+    # Token rows are only inserted when the email actually sends.
+    assert len(tokens) == EMAIL_LIMIT_PER_HOUR
+
+
+def test_ip_limit_blocks_twentyfirst_send(client: TestClient, session: Session) -> None:
+    """20 sends from one IP (across different emails) succeed; the 21st
+    is suppressed even though no individual email is over its own limit."""
+    with respx.mock() as mock:
+        route = mock.post(RESEND_ENDPOINT).mock(return_value=RESEND_OK)
+        for i in range(IP_LIMIT_PER_HOUR):
+            response = client.post("/auth/login", data={"email": f"user{i}@example.com"})
+            assert response.status_code == 200
+        assert route.call_count == IP_LIMIT_PER_HOUR
+
+        suppressed = client.post("/auth/login", data={"email": "user-extra@example.com"})
+
+    assert suppressed.status_code == 200
+    assert route.call_count == IP_LIMIT_PER_HOUR  # Resend NOT called the 21st time
+
+
+def test_suppressed_response_is_byte_identical_to_allowed_response(
+    client: TestClient, session: Session
+) -> None:
+    """An attacker probing the endpoint must not be able to distinguish
+    a suppressed call from a successful one. Same status, same body."""
+    with respx.mock() as mock:
+        mock.post(RESEND_ENDPOINT).mock(return_value=RESEND_OK)
+        allowed = client.post("/auth/login", data={"email": "alice@example.com"})
+        # Burn the remaining four sends so the next call is suppressed.
+        for _ in range(EMAIL_LIMIT_PER_HOUR - 1):
+            client.post("/auth/login", data={"email": "alice@example.com"})
+        suppressed = client.post("/auth/login", data={"email": "alice@example.com"})
+
+    assert allowed.status_code == suppressed.status_code == 200
+    assert allowed.content == suppressed.content
+
+
+def test_fixed_bucket_consume_is_atomic_at_limit() -> None:
+    """Unit-level: a fresh limiter at limit=3 allows exactly 3 then refuses."""
+    limiter = FixedBucketRateLimiter(max_per_hour=3)
+    assert [limiter.consume("k") for _ in range(5)] == [True, True, True, False, False]
+    # Different keys have independent buckets.
+    assert limiter.consume("other") is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,19 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 import app.models  # noqa: F401  -- register tables on SQLModel.metadata
+from app.auth.rate_limit import email_limiter, ip_limiter
 from app.db import get_session
 from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiters() -> Generator[None, None, None]:
+    """Module-level limiter state would otherwise leak between tests."""
+    email_limiter._reset()
+    ip_limiter._reset()
+    yield
+    email_limiter._reset()
+    ip_limiter._reset()
 
 
 @pytest.fixture(name="session")


### PR DESCRIPTION
## Ticket
Closes #15 — In-process rate limiter for magic link send
Project board: https://github.com/orgs/vibeacademy/projects/17

## Summary
Closes the open-mail-relay gap on `POST /auth/login` that prior reviewers flagged on both PR #41 and PR #42. A small in-process `FixedBucketRateLimiter` keyed on `(string, hour-of-epoch)` enforces the architecture's caps: 5 sends per email per hour, 20 per IP per hour. Suppressed requests return the same template as a successful send so enumeration safety is preserved.

## Changes Made
- `app/auth/rate_limit.py` — `FixedBucketRateLimiter` (atomic `consume()`), two module-level instances (`email_limiter` and `ip_limiter`), and `check_magic_link_rate_limit(email=..., client_ip=...)` which consumes one slot from each and logs at INFO when either limit is hit. State is process-local; resets on restart.
- `app/auth/routes.py` — `POST /auth/login` consults `check_magic_link_rate_limit` BEFORE any DB write or outbound HTTP call. On suppress, returns the `check_email.html` template without persisting a `MagicLinkToken` row (suppressed requests don't pollute the table). Client IP comes from `request.client.host`, which respects X-Forwarded headers thanks to the `ProxyHeadersMiddleware` registered in PR #42.
- `tests/conftest.py` — autouse fixture resets both limiters between every test so prior auth tests don't accumulate counters.

## Security guardrails honored (per ticket B. Guardrails)
- In-process limiter; no Redis or external dependency added
- Suppressed responses use the **same template, same status, byte-identical body** as a successful send (verified by `test_suppressed_response_is_byte_identical_to_allowed_response`)
- No 429 visible to the user; the rate-limit event is logged server-side only
- Email key is lowercased before consume so case-folded duplicates count toward the same bucket

## Out of scope (separate ticket if ever needed)
- Multi-instance scale (would need Redis/shared store)
- Per-IP sliding window vs the fixed hour bucket implemented here
- 429 status code or `Retry-After` header (would create an enumeration oracle — intentionally not added)

## Testing
### Automated
- [x] `uv run pytest --cov=app` — **48/48 pass, 94% coverage**
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues found in 21 source files

### Coverage of DoD bullets
- [x] 6th send to the same email within an hour does NOT call Resend → `test_email_limit_blocks_sixth_send`
- [x] 21st send from the same IP within an hour does NOT call Resend → `test_ip_limit_blocks_twentyfirst_send` (uses 21 different emails so no single email hits its own cap first)
- [x] Response is byte-identical whether limit was hit or not → `test_suppressed_response_is_byte_identical_to_allowed_response`
- [x] Unit test for the limiter's atomic `consume()` contract → `test_fixed_bucket_consume_is_atomic_at_limit`

## Reviewer-friendly notes
- The limiter is consulted **before** the DB write so suppressed bursts don't waste rows. As a side effect, `magic_link_tokens` row count for a given email is a (very weak) signal of how many real sends went out — but only visible to someone with DB access, which doesn't change the threat model.
- `_reset()` on the limiter is underscore-prefixed because it's test-only — production state resets via process restart, not a method call.
- Email key uses `.lower()` so `Alice@example.com` and `alice@example.com` share a counter. Reasonable, since RFC 5321 says local-part is technically case-sensitive but in practice mail providers fold.

## Checklist
- [x] All tests pass (48/48)
- [x] Code follows project standards
- [x] No linting warnings
- [x] mypy clean