### PR TITLE
[#14] feat(auth): POST /auth/logout clears session

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -129,3 +129,16 @@ def verify(
     profile = session.get(TasteProfile, user.id)
     target = "/" if profile is not None else "/onboard"
     return RedirectResponse(target, status_code=302)
+
+
+@router.post("/logout")
+def logout(request: Request) -> RedirectResponse:
+    """Clear the session cookie and redirect to the home page.
+
+    POST-only — a GET-triggered logout could be CSRF'd by any link that
+    a third-party site renders. The session is cleared unconditionally;
+    an anonymous request still gets a clean 302 home (the no-op is
+    deliberately quiet).
+    """
+    request.session.clear()
+    return RedirectResponse("/", status_code=302)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,6 +12,13 @@
   </head>
   <body>
     <main class="container">
+      {% if request.session.get("user_id") %}
+        <nav style="display:flex;justify-content:flex-end;">
+          <form action="/auth/logout" method="post" style="margin:0;">
+            <button type="submit" class="secondary">Log out</button>
+          </form>
+        </nav>
+      {% endif %}
       {% block content %}{% endblock %}
     </main>
   </body>

--- a/tests/auth/test_logout.py
+++ b/tests/auth/test_logout.py
@@ -1,0 +1,75 @@
+"""Tests for POST /auth/logout.
+
+Covers the Definition of Done items from #14:
+
+* POST /auth/logout for an authenticated session returns 302 to /
+* the session cookie no longer authenticates a follow-up request
+* GET /auth/logout returns 405 (Method Not Allowed)
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.auth.tokens import generate_token, hash_token
+from app.models import MagicLinkToken
+
+
+def _sign_in(client: TestClient, session: Session, email: str) -> None:
+    """Drive the verify endpoint to set a real signed session cookie on
+    the TestClient. After this returns, ``client.cookies['session']`` is
+    the Starlette-signed cookie value."""
+    raw = generate_token()
+    session.add(
+        MagicLinkToken(
+            email=email,
+            token_hash=hash_token(raw),
+            expires_at=datetime.now(UTC) + timedelta(minutes=15),
+        )
+    )
+    session.commit()
+    response = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+    assert response.status_code == 302
+    assert client.cookies.get("session"), "verify did not set a session cookie"
+
+
+def test_logout_redirects_home_for_authenticated_session(
+    client: TestClient, session: Session
+) -> None:
+    _sign_in(client, session, "alice@example.com")
+
+    response = client.post("/auth/logout", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+
+
+def test_logout_clears_session_so_followup_is_unauthenticated(
+    client: TestClient, session: Session
+) -> None:
+    """After logout, the index page must NOT render the logout button —
+    which is the proxy for 'the session cookie no longer authenticates'."""
+    _sign_in(client, session, "alice@example.com")
+
+    # While authenticated, the home page renders the Log out button.
+    pre_logout = client.get("/")
+    assert "Log out" in pre_logout.text
+
+    client.post("/auth/logout", follow_redirects=False)
+
+    post_logout = client.get("/")
+    assert "Log out" not in post_logout.text
+
+
+def test_get_logout_returns_405(client: TestClient) -> None:
+    response = client.get("/auth/logout")
+    assert response.status_code == 405
+
+
+def test_logout_when_anonymous_still_returns_302(client: TestClient) -> None:
+    """No active session is a no-op clear; the user lands on / either way.
+    A 302 (not 401) avoids leaking auth state via the response code."""
+    response = client.post("/auth/logout", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,11 @@ def client_fixture(session: Session) -> Generator[TestClient, None, None]:
         yield session
 
     app.dependency_overrides[get_session] = get_session_override
-    with TestClient(app) as client:
+    # base_url=https so SessionMiddleware's Secure cookie survives the
+    # httpx cookie jar — without this, the cookie is set on the response
+    # but stripped on the next request because Secure cookies don't ride
+    # http://. Tests can still send X-Forwarded-Proto explicitly to
+    # exercise ProxyHeadersMiddleware overrides.
+    with TestClient(app, base_url="https://testserver") as client:
         yield client
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Ticket
Closes #14 — Logout endpoint POST /auth/logout
Project board: https://github.com/orgs/vibeacademy/projects/17

## Summary
Closes the user-facing auth flow opened by #12 (request) and #13 (verify). `POST /auth/logout` calls `request.session.clear()` and 302s home. The base template renders a session-conditional "Log out" form-button — a plain `<form method="post">`, no JS dependency.

## Changes Made
- `app/auth/routes.py` — `POST /auth/logout` handler. Unconditional clear + redirect. POST-only (CSRF safety).
- `app/templates/base.html` — renders a Log out button inside a `<nav>` when `request.session.get("user_id")` is set. Available to every template that extends base.
- `tests/auth/test_logout.py` — 4 tests covering the full DoD plus anonymous-POST behavior.
- `tests/conftest.py` — TestClient now uses `base_url="https://testserver"` so Starlette `SessionMiddleware`'s `Secure` cookie survives the httpx cookie jar. Without this fix, `client.cookies` would hold the cookie but httpx strips it on the next request because Secure cookies don't ride `http://`. All 48 prior tests continue to pass on the https base URL.

## Security guardrails honored
- POST-only (per ticket B. Guardrails) — a GET-triggered logout could be CSRF'd by any link a third-party site renders
- `request.session.clear()` wipes the entire session, not just `user_id` (per ticket B. Guardrails)
- Anonymous POST returns 302 (not 401) so the response code doesn't leak auth state
- No other middleware or routes touched

## Testing
### Automated
- [x] `uv run pytest --cov=app` — **52/52 pass, 94% coverage**
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues found in 21 source files

### Coverage of DoD bullets
- [x] POST /auth/logout for an authenticated session returns 302 to / → `test_logout_redirects_home_for_authenticated_session`
- [x] Session cookie no longer authenticates a follow-up request → `test_logout_clears_session_so_followup_is_unauthenticated` (proxied via the Log out button no longer rendering on `/`)
- [x] GET /auth/logout returns 405 → `test_get_logout_returns_405`

Bonus test: `test_logout_when_anonymous_still_returns_302` to lock in the no-leak-via-status-code behavior.

## Reviewer-friendly notes
- The `request.session.get("user_id")` check in base.html works because Jinja can call methods on `request` and Starlette's `request.session` is a dict-like proxy over the signed cookie payload.
- The conftest fix is genuinely necessary for #14 specifically — earlier auth tests never made follow-up requests that DEPENDED on the session being sent back, so the Secure-cookie-stripping was masked. This is the first ticket where session-cookie round-trip matters at the test level.
- TestClient base URL change should be invisible to existing tests: TestClient uses ASGI directly, not real HTTP, so the URL scheme only affects cookie-jar logic.

## Checklist
- [x] All tests pass (52/52)
- [x] Code follows project standards
- [x] No linting warnings
- [x] mypy clean