### PR TITLE
[#25] feat(onboard): taste questionnaire form GET/POST /onboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from app.api import health
 from app.auth import routes as auth_routes
 from app.config import get_settings
+from app.onboard import routes as onboard_routes
 from app.templates import templates
 
 _settings = get_settings()
@@ -44,6 +45,7 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 app.include_router(health.router)
 app.include_router(auth_routes.router)
+app.include_router(onboard_routes.router)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/app/onboard/__init__.py
+++ b/app/onboard/__init__.py
@@ -1,0 +1,7 @@
+"""Taste profile onboarding.
+
+GET /onboard renders a checkbox form populated from the taxonomy enums.
+POST /onboard validates submitted values against the same enums and
+UPSERTs a ``TasteProfile`` row keyed on ``user_id``. Authentication is
+required; anonymous callers get a 302 to ``/auth/login``.
+"""

--- a/app/onboard/routes.py
+++ b/app/onboard/routes.py
@@ -1,0 +1,102 @@
+"""GET/POST /onboard — taste questionnaire form.
+
+The verify endpoint (#13) redirects new users here; we close that loop
+by rendering a form they can actually submit. POST validates every
+submitted tag against the taxonomy enums (Genre / Tone / FormLength)
+and UPSERTs a ``TasteProfile`` row keyed on ``user_id`` so a user can
+edit their answers without duplicating rows.
+"""
+
+from enum import StrEnum
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from sqlmodel import Session
+
+from app.auth.session import optional_current_user
+from app.db import get_session
+from app.models.taxonomy import FormLength, Genre, Tone
+from app.models.user import TasteProfile, User
+from app.templates import templates
+
+router = APIRouter(tags=["onboard"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+MaybeUser = Annotated[User | None, Depends(optional_current_user)]
+
+
+def _validate_tags(values: list[str], enum_type: type[StrEnum]) -> None:
+    """Raise 422 if any element of ``values`` isn't a valid enum member.
+
+    We keep the caller's original strings instead of coercing to the enum
+    so what lands in the ``text[]`` column matches the enum's ``.value``.
+    """
+    valid = {member.value for member in enum_type}
+    unknown = [v for v in values if v not in valid]
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Unknown {enum_type.__name__} values: {unknown}",
+        )
+
+
+@router.get("/onboard", response_class=HTMLResponse)
+def onboard_form(request: Request, user: MaybeUser) -> Response:
+    if user is None:
+        return RedirectResponse("/auth/login", status_code=302)
+    return templates.TemplateResponse(
+        request,
+        "onboard/form.html",
+        {"genres": list(Genre), "tones": list(Tone), "form_lengths": list(FormLength)},
+    )
+
+
+@router.post("/onboard")
+def onboard_submit(
+    request: Request,
+    session: SessionDep,
+    user: MaybeUser,
+    genres: Annotated[list[str] | None, Form()] = None,
+    tones: Annotated[list[str] | None, Form()] = None,
+    form_lengths: Annotated[list[str] | None, Form()] = None,
+) -> Response:
+    if user is None:
+        return RedirectResponse("/auth/login", status_code=302)
+
+    genres = genres or []
+    tones = tones or []
+    form_lengths = form_lengths or []
+
+    if not genres:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="At least one genre is required",
+        )
+
+    _validate_tags(genres, Genre)
+    _validate_tags(tones, Tone)
+    _validate_tags(form_lengths, FormLength)
+
+    # UPSERT: existing TasteProfile rows are updated in place so a user
+    # editing their answers doesn't accumulate duplicate rows. The PK
+    # is user_id (1:1 with users), so a SELECT-then-UPDATE-or-INSERT is
+    # safe under sequential clicks.
+    profile = session.get(TasteProfile, user.id)
+    if profile is None:
+        session.add(
+            TasteProfile(
+                user_id=user.id,
+                genres=genres,
+                tones=tones,
+                form_lengths=form_lengths,
+            )
+        )
+    else:
+        profile.genres = genres
+        profile.tones = tones
+        profile.form_lengths = form_lengths
+        session.add(profile)
+    session.commit()
+
+    return RedirectResponse("/", status_code=302)

--- a/app/templates/onboard/form.html
+++ b/app/templates/onboard/form.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}Tell us what you read · Croissantfella{% endblock %}
+{% block content %}
+<h1>Tell us what you read</h1>
+<p>Pick the kinds of writing you'd like to see. You can change these later.</p>
+<form method="post">
+  <fieldset>
+    <legend>Genres <small>(at least one)</small></legend>
+    {% for g in genres %}
+      <label>
+        <input type="checkbox" name="genres" value="{{ g.value }}" />
+        {{ g.value.replace("_", " ") }}
+      </label>
+    {% endfor %}
+  </fieldset>
+  <fieldset>
+    <legend>Tones <small>(optional)</small></legend>
+    {% for t in tones %}
+      <label>
+        <input type="checkbox" name="tones" value="{{ t.value }}" />
+        {{ t.value.replace("_", " ") }}
+      </label>
+    {% endfor %}
+  </fieldset>
+  <fieldset>
+    <legend>Form lengths <small>(optional)</small></legend>
+    {% for fl in form_lengths %}
+      <label>
+        <input type="checkbox" name="form_lengths" value="{{ fl.value }}" />
+        {{ fl.value.replace("_", " ") }}
+      </label>
+    {% endfor %}
+  </fieldset>
+  <button type="submit">Save and continue</button>
+</form>
+{% endblock %}

--- a/tests/onboard/test_form.py
+++ b/tests/onboard/test_form.py
@@ -1,0 +1,142 @@
+"""Tests for GET/POST /onboard.
+
+Covers the Definition of Done items from #25:
+
+* POST /onboard with valid taxonomy values creates a TasteProfile and
+  redirects to /
+* a second POST UPSERTs (does not error or duplicate)
+* an unknown taxonomy value returns 422
+* POST with empty genres returns 422
+* an anonymous request returns 302 to /auth/login
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.auth.tokens import generate_token, hash_token
+from app.models import FormLength, Genre, MagicLinkToken, TasteProfile, Tone
+
+
+def _sign_in(client: TestClient, session: Session, email: str) -> None:
+    """Drive /auth/verify to set a real session cookie on the TestClient."""
+    raw = generate_token()
+    session.add(
+        MagicLinkToken(
+            email=email,
+            token_hash=hash_token(raw),
+            expires_at=datetime.now(UTC) + timedelta(minutes=15),
+        )
+    )
+    session.commit()
+    response = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+    assert response.status_code == 302
+
+
+def test_get_onboard_redirects_anonymous_to_login(client: TestClient) -> None:
+    response = client.get("/onboard", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/auth/login"
+
+
+def test_post_onboard_redirects_anonymous_to_login(client: TestClient) -> None:
+    response = client.post(
+        "/onboard",
+        data={"genres": [Genre.LITERARY.value]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/auth/login"
+
+
+def test_get_onboard_renders_form_for_authenticated_user(
+    client: TestClient, session: Session
+) -> None:
+    _sign_in(client, session, "alice@example.com")
+    response = client.get("/onboard")
+    assert response.status_code == 200
+    # Every enum value should appear as a checkbox.
+    for g in Genre:
+        assert f'value="{g.value}"' in response.text
+    for t in Tone:
+        assert f'value="{t.value}"' in response.text
+    for fl in FormLength:
+        assert f'value="{fl.value}"' in response.text
+
+
+def test_post_onboard_creates_taste_profile_and_redirects_home(
+    client: TestClient, session: Session
+) -> None:
+    _sign_in(client, session, "alice@example.com")
+    response = client.post(
+        "/onboard",
+        data={
+            "genres": [Genre.LITERARY.value, Genre.SCI_FI.value],
+            "tones": [Tone.CONTEMPLATIVE.value],
+            "form_lengths": [FormLength.SHORT_STORY.value],
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+
+    profiles = list(session.exec(select(TasteProfile)))
+    assert len(profiles) == 1
+    assert sorted(profiles[0].genres) == sorted([Genre.LITERARY.value, Genre.SCI_FI.value])
+    assert profiles[0].tones == [Tone.CONTEMPLATIVE.value]
+    assert profiles[0].form_lengths == [FormLength.SHORT_STORY.value]
+
+
+def test_post_onboard_upserts_on_second_submit(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "alice@example.com")
+    client.post(
+        "/onboard",
+        data={"genres": [Genre.LITERARY.value]},
+        follow_redirects=False,
+    )
+    response = client.post(
+        "/onboard",
+        data={"genres": [Genre.FANTASY.value, Genre.HORROR.value]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    # SQLAlchemy session may have stale cache from the first commit;
+    # expire_all() forces the next query to hit the DB.
+    session.expire_all()
+    profiles = list(session.exec(select(TasteProfile)))
+    assert len(profiles) == 1
+    assert sorted(profiles[0].genres) == sorted([Genre.FANTASY.value, Genre.HORROR.value])
+
+
+def test_post_onboard_with_empty_genres_returns_422(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "alice@example.com")
+    response = client.post(
+        "/onboard",
+        data={"genres": []},
+        follow_redirects=False,
+    )
+    assert response.status_code == 422
+
+
+def test_post_onboard_with_unknown_genre_returns_422(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "alice@example.com")
+    response = client.post(
+        "/onboard",
+        data={"genres": ["not-a-real-genre"]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 422
+
+
+def test_post_onboard_with_unknown_tone_returns_422(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "alice@example.com")
+    response = client.post(
+        "/onboard",
+        data={
+            "genres": [Genre.LITERARY.value],
+            "tones": ["definitely-not-a-tone"],
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Ticket
Closes #25 — Taste questionnaire form GET/POST /onboard
Project board: https://github.com/orgs/vibeacademy/projects/17

## Summary
Closes the auth-to-onboard hole opened by #13: the verify endpoint redirects new users to `/onboard`, which now renders a checkbox form populated from the `Genre`/`Tone`/`FormLength` taxonomy enums. POST validates submitted values against those enums and UPSERTs a `TasteProfile` row keyed on `user_id` so users can edit answers without duplicating rows. First real consumer of `app/auth/session.py::optional_current_user` (was 0% covered until now).

## Changes Made
- `app/onboard/routes.py` — `GET /onboard` renders the form (lists `Genre`/`Tone`/`FormLength` for the template); `POST /onboard` validates + UPSERTs. Both check `optional_current_user`: `None` → 302 to `/auth/login`. Unknown taxonomy values raise `HTTPException(422)`; empty genres raises 422 (architecture requires ≥1).
- `app/templates/onboard/form.html` — extends `base.html`, three fieldsets of checkboxes. Plain HTML form, no HTMX (full-page submit per ticket scope).
- `app/main.py` — registers the onboard router after auth.
- `tests/onboard/test_form.py` — 8 tests covering the full DoD plus edge cases.

## Security & ticket guardrails
- **Auth required**: both routes redirect anonymous callers to `/auth/login` (per ticket B. Guardrails)
- **Tag validation**: every submitted value must be in the corresponding `StrEnum`; anything else → 422 (per ticket B. Guardrails)
- **At least one genre**: empty `genres` → 422 (per ticket B. Guardrails)
- **POST is idempotent**: existing `TasteProfile` rows are updated in place via `session.get(TasteProfile, user.id)` + mutate (per ticket B. Guardrails)
- **Stays on /onboard until success**: POST only redirects to `/` after the UPSERT commits (per ticket B. Guardrails)

## Out of scope (separate tickets)
- #26 — force-onboarding redirect (server-side: hijack `/` for users without a TasteProfile)
- #27 — edit-taste-profile at `/settings`
- 422-with-re-rendered-form-and-error-messages (currently 422 returns FastAPI's default JSON; reasonable trade-off until #27 lands)
- HTMX progressive enhancement on the form

## Testing
### Automated
- [x] `uv run pytest --cov=app` — **60/60 pass, 98% coverage** (up from 94%; new code in `app/onboard/*` is 100% covered)
- [x] `uv run ruff check .` — clean (had to flip `= []` defaults to `None` + initialize-in-body for the B006 bugbear rule)
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues found in 23 source files

### Coverage of DoD bullets
- [x] POST /onboard with valid taxonomy creates a TasteProfile and redirects to / → `test_post_onboard_creates_taste_profile_and_redirects_home`
- [x] A second POST UPSERTs without erroring or duplicating → `test_post_onboard_upserts_on_second_submit`
- [x] Unknown taxonomy value → 422 → `test_post_onboard_with_unknown_genre_returns_422` and `..._unknown_tone_returns_422`
- [x] Empty genres → 422 → `test_post_onboard_with_empty_genres_returns_422`
- [x] Anonymous → 302 to /auth/login → `test_get_onboard_redirects_anonymous_to_login` and `test_post_onboard_redirects_anonymous_to_login`

## Reviewer-friendly notes
- `optional_current_user` (returns `None`) is used instead of `current_user` (raises 401) because HTML pages need redirect semantics. `current_user` remains the right choice for future JSON/HTMX-fragment endpoints.
- The form values arrive as `list[str] | None = None`; the route normalizes `None → []` immediately. This satisfies ruff's B006 (no mutable defaults) and types correctly under mypy strict.
- The UPSERT pattern is SELECT-then-mutate-or-INSERT. Safe under sequential user clicks; not concurrency-safe under parallel POSTs from the same user. Same trade-off class as the `User` insert race noted on #13's reviewer feedback. Realistic risk is low (user double-clicking submit) and the unique PK constraint catches duplicate inserts anyway.
- `expire_all()` in the UPSERT test forces SQLAlchemy to refresh from the DB so we see the second POST's mutations rather than the first commit's cached object.

## Checklist
- [x] All tests pass (60/60)
- [x] Code follows project standards
- [x] No linting warnings
- [x] mypy clean