### PR TITLE
[#16] feat(users): public profile page GET /u/{display_name}

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.auth import routes as auth_routes
 from app.config import get_settings
 from app.onboard import routes as onboard_routes
 from app.templates import templates
+from app.users import routes as users_routes
 
 _settings = get_settings()
 
@@ -46,6 +47,7 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 app.include_router(health.router)
 app.include_router(auth_routes.router)
 app.include_router(onboard_routes.router)
+app.include_router(users_routes.router)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/app/templates/users/profile.html
+++ b/app/templates/users/profile.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}{{ profile_user.display_name }} · Croissantfella{% endblock %}
+{% block content %}
+<hgroup>
+  <h1>{{ profile_user.display_name }}</h1>
+  {% if profile_user.bio %}
+    <p>{{ profile_user.bio }}</p>
+  {% endif %}
+</hgroup>
+
+{% if posts %}
+  <section>
+    <h2>Posts</h2>
+    <ul>
+      {% for post in posts %}
+        <li>
+          <article>
+            <header>
+              <h3><a href="/posts/{{ post.id }}">{{ post.title }}</a></h3>
+              {% if post.published_at %}
+                <small>{{ post.published_at.strftime("%Y-%m-%d") }}</small>
+              {% endif %}
+            </header>
+            <p>{{ post.body[:200] }}{% if post.body|length > 200 %}…{% endif %}</p>
+          </article>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% else %}
+  <p>No posts yet.</p>
+{% endif %}
+{% endblock %}

--- a/app/users/__init__.py
+++ b/app/users/__init__.py
@@ -1,0 +1,7 @@
+"""Public user surfaces.
+
+GET /u/{display_name} renders an author's profile with their published
+posts in reverse-chronological order. Reachable anonymously — no
+``current_user`` dependency. Lookup is case-insensitive but the URL is
+canonicalized to the stored case via a 302 redirect.
+"""

--- a/app/users/routes.py
+++ b/app/users/routes.py
@@ -1,0 +1,60 @@
+"""GET /u/{display_name} — public profile page."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from sqlalchemy import desc, func
+from sqlmodel import Session, select
+
+from app.db import get_session
+from app.models.post import Post
+from app.models.taxonomy import ContentStatus
+from app.models.user import User
+from app.templates import templates
+
+PROFILE_POST_LIMIT = 50
+
+router = APIRouter(tags=["users"])
+
+SessionDep = Annotated[Session, Depends(get_session)]
+
+
+@router.get("/u/{display_name}", response_class=HTMLResponse)
+def profile(
+    request: Request,
+    session: SessionDep,
+    display_name: str,
+) -> Response:
+    """Render the public profile page for ``display_name``.
+
+    Reachable anonymously. 404 if no user matches (case-insensitively).
+    302 redirect to the canonical-case URL if the URL's case differs
+    from the stored value. Only ``status='published'`` posts are listed.
+    """
+    user = session.exec(
+        select(User).where(func.lower(User.display_name) == display_name.lower())
+    ).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    if user.display_name != display_name:
+        return RedirectResponse(f"/u/{user.display_name}", status_code=302)
+
+    # Use a string column name for order_by so mypy doesn't trip on
+    # SQLModel's Python-typed column attribute (see PATTERN-LIBRARY.md #16).
+    posts = list(
+        session.exec(
+            select(Post)
+            .where(Post.author_id == user.id)
+            .where(Post.status == ContentStatus.PUBLISHED.value)
+            .order_by(desc("published_at"))
+            .limit(PROFILE_POST_LIMIT)
+        )
+    )
+
+    return templates.TemplateResponse(
+        request,
+        "users/profile.html",
+        {"profile_user": user, "posts": posts},
+    )

--- a/tests/users/test_profile.py
+++ b/tests/users/test_profile.py
@@ -1,0 +1,158 @@
+"""Tests for GET /u/{display_name} — public profile page.
+
+Covers the Definition of Done items from #16:
+
+* GET /u/{name} returns 200 for an existing user with posts, and the
+  response HTML contains each published post's title
+* ``pending_moderation`` and ``blocked`` posts are NOT in the response
+* GET /u/UNKNOWN returns 404
+* the response does not contain the user's email
+* case-insensitive lookup redirects to the canonical case
+"""
+
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.models import ContentStatus, FormLength, Genre, Post, Tone, User
+
+
+def _make_post(
+    session: Session,
+    *,
+    author: User,
+    title: str,
+    status: str,
+    published_at: datetime | None = None,
+    body: str = "Some text.",
+) -> Post:
+    post = Post(
+        author_id=author.id,
+        title=title,
+        body=body,
+        genres=[Genre.LITERARY.value],
+        tones=[Tone.CONTEMPLATIVE.value],
+        form_length=FormLength.FLASH.value,
+        status=status,
+        published_at=published_at,
+    )
+    session.add(post)
+    session.commit()
+    session.refresh(post)
+    return post
+
+
+def _make_user(session: Session, *, email: str, display_name: str) -> User:
+    user = User(email=email, display_name=display_name)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def test_profile_returns_200_with_published_post_titles(
+    client: TestClient, session: Session
+) -> None:
+    alice = _make_user(session, email="alice@example.com", display_name="Alice")
+    _make_post(
+        session,
+        author=alice,
+        title="First Story",
+        status=ContentStatus.PUBLISHED.value,
+        published_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    _make_post(
+        session,
+        author=alice,
+        title="Second Story",
+        status=ContentStatus.PUBLISHED.value,
+        published_at=datetime(2026, 5, 2, tzinfo=UTC),
+    )
+
+    response = client.get("/u/Alice")
+    assert response.status_code == 200
+    assert "First Story" in response.text
+    assert "Second Story" in response.text
+
+
+def test_profile_omits_pending_and_blocked_posts(client: TestClient, session: Session) -> None:
+    alice = _make_user(session, email="alice@example.com", display_name="Alice")
+    _make_post(
+        session,
+        author=alice,
+        title="Published Story",
+        status=ContentStatus.PUBLISHED.value,
+        published_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    _make_post(
+        session,
+        author=alice,
+        title="Pending Story",
+        status=ContentStatus.PENDING_MODERATION.value,
+    )
+    _make_post(
+        session,
+        author=alice,
+        title="Blocked Story",
+        status=ContentStatus.BLOCKED.value,
+    )
+
+    response = client.get("/u/Alice")
+    assert response.status_code == 200
+    assert "Published Story" in response.text
+    assert "Pending Story" not in response.text
+    assert "Blocked Story" not in response.text
+
+
+def test_unknown_user_returns_404(client: TestClient, session: Session) -> None:
+    response = client.get("/u/nobody-here")
+    assert response.status_code == 404
+
+
+def test_profile_does_not_leak_email(client: TestClient, session: Session) -> None:
+    _make_user(session, email="alice@example.com", display_name="Alice")
+    response = client.get("/u/Alice")
+    assert response.status_code == 200
+    assert "alice@example.com" not in response.text
+
+
+def test_profile_does_not_leak_user_uuid(client: TestClient, session: Session) -> None:
+    """Internal IDs are an architecture guardrail: profile HTML must
+    not include the user's UUID even though Post links use post.id."""
+    alice = _make_user(session, email="alice@example.com", display_name="Alice")
+    response = client.get("/u/Alice")
+    assert str(alice.id) not in response.text
+
+
+def test_case_insensitive_lookup_redirects_to_canonical(
+    client: TestClient, session: Session
+) -> None:
+    _make_user(session, email="alice@example.com", display_name="Alice")
+
+    response = client.get("/u/alice", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/u/Alice"
+
+
+def test_anonymous_can_view_profile(client: TestClient, session: Session) -> None:
+    """No sign-in required; auth-less browsers reach the page."""
+    _make_user(session, email="alice@example.com", display_name="Alice")
+    response = client.get("/u/Alice")
+    assert response.status_code == 200
+    # The session-conditional Log out button in base.html must NOT appear
+    # for an anonymous visitor.
+    assert "Log out" not in response.text
+
+
+def test_profile_post_link_uses_post_uuid(client: TestClient, session: Session) -> None:
+    alice = _make_user(session, email="alice@example.com", display_name="Alice")
+    post = _make_post(
+        session,
+        author=alice,
+        title="A Story",
+        status=ContentStatus.PUBLISHED.value,
+        published_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    response = client.get("/u/Alice")
+    assert f"/posts/{post.id}" in response.text


### PR DESCRIPTION
## Ticket
Closes #16 — Public profile page GET /u/{display_name}
Project board: https://github.com/orgs/vibeacademy/projects/17

## Summary
First user-facing read endpoint. `GET /u/{display_name}` renders an author's bio plus their published posts in reverse-chronological order. Anonymous-viewable (no auth required). Case-insensitive lookup with a 302 redirect to the canonical-case URL when the URL differs from the stored `display_name`.

## Changes Made
- `app/users/{__init__,routes}.py` — `GET /u/{display_name}`. Lookup via `func.lower(User.display_name) == display_name.lower()`. Published-posts query uses `desc("published_at")` with the string column name to avoid the SQLModel mypy trip on `.desc()` (per `docs/PATTERN-LIBRARY.md` #16). Cap at 50 posts.
- `app/templates/users/profile.html` — extends `base.html`. Renders `display_name`, optional bio, and a list of posts (title, date, 200-char excerpt) each linking to `/posts/{id}`. Carefully excludes `profile_user.email` and `profile_user.id` from the markup.
- `app/main.py` — registers the users router after onboard.
- `tests/users/test_profile.py` — 8 tests covering the full DoD plus anonymous-view, no-UUID-leak, and post-link-uses-uuid.

## Security guardrails honored
- **Anonymous reachable** (no `current_user`/`optional_current_user` dep) — anyone can view
- **Only published posts listed** — `WHERE status = 'published'` filters out `pending_moderation` and `blocked`
- **Case-insensitive lookup with canonical redirect** — `/u/alice` → 302 → `/u/Alice` if stored as "Alice"
- **No email or UUID in response HTML** — verified by `test_profile_does_not_leak_email` and `test_profile_does_not_leak_user_uuid`

## Testing
### Automated
- [x] `uv run pytest --cov=app` — **68/68 pass, 98% coverage** (new `app/users/*` at 100%)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues found in 25 source files

### Coverage of DoD bullets
- [x] 200 + published-post titles in HTML → `test_profile_returns_200_with_published_post_titles`
- [x] pending/blocked posts excluded → `test_profile_omits_pending_and_blocked_posts`
- [x] unknown user → 404 → `test_unknown_user_returns_404`
- [x] response does not contain email → `test_profile_does_not_leak_email`
- [x] case-insensitive lookup redirects to canonical → `test_case_insensitive_lookup_redirects_to_canonical`

## Reviewer-friendly notes
- `LOWER(display_name)` is a table scan at scale; at MVP target (250 users) that's a non-issue, but if profile views become hot a functional index `CREATE INDEX users_display_name_lower ON users (LOWER(display_name))` would be the natural follow-up.
- No unique constraint on `users.display_name` at the schema level (see #10's reviewer note). Two users with the same case-insensitive name would collide on this lookup (`.first()` picks one). Realistic risk: low until we get to thousands of users; tracked as part of the broader auth-polish backlog.
- `desc("published_at")` (string column name) is the project's standard mypy-friendly idiom; see `docs/PATTERN-LIBRARY.md` #16.
- The 404 returns FastAPI's default JSON detail. A future custom 404 HTML page would be a polish item.
- Post link target `/posts/{id}` doesn't exist yet — #19 (Post detail page) ships that route. Profile page renders the link regardless; clicking will 404 until #19 lands.

## Out of scope (separate tickets)
- #17 — Profile edit form at `/settings`
- #19 — Post detail page (the link target on the profile)
- Email/UUID-leak guard via a custom 404 HTML page

## Checklist
- [x] All tests pass (68/68)
- [x] Code follows project standards
- [x] No linting warnings
- [x] mypy clean