### PR TITLE
[#26] feat(onboard): force redirect to /onboard for users without taste profile

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,19 +17,33 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from app.api import health
 from app.auth import routes as auth_routes
 from app.config import get_settings
+from app.db import engine
 from app.onboard import routes as onboard_routes
+from app.onboard.middleware import RequireTasteProfileMiddleware
 from app.templates import templates
 from app.users import routes as users_routes
 
 _settings = get_settings()
 
 app = FastAPI(title="Croissantfella")
+# app.state.engine is read by RequireTasteProfileMiddleware so tests can
+# substitute an in-memory engine; production reads the module-level
+# Neon-bound engine. Storing it here makes the override testable via
+# app.state without globally monkeypatching app.db.
+app.state.engine = engine
 # Cloud Run terminates TLS at the proxy and forwards via X-Forwarded-Proto
 # and X-Forwarded-Host. Without this middleware, request.url returns the
 # internal Cloud Run origin (http://localhost:8080) and absolute URLs
 # constructed from it (magic links, OAuth redirects) silently break in
 # preview and production. See docs/PATTERN-LIBRARY.md pitfall #3.
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+# RequireTasteProfileMiddleware reads request.session, so it MUST be
+# added BEFORE SessionMiddleware in code order (Starlette wraps in stack
+# order; last-added is outermost and runs first on the way in). After
+# this layout: incoming request → SessionMiddleware (populates session)
+# → RequireTasteProfile (reads session, conditionally redirects) →
+# ProxyHeaders → route handler.
+app.add_middleware(RequireTasteProfileMiddleware)
 # Signed session cookie used by the magic-link verify flow. https_only=True
 # adds the `Secure` attribute so the cookie only travels over TLS;
 # same_site="lax" defends against CSRF on top-level GET while still letting

--- a/app/onboard/middleware.py
+++ b/app/onboard/middleware.py
@@ -1,0 +1,66 @@
+"""Force authenticated users without a TasteProfile to /onboard.
+
+A signed-in user who never completed the questionnaire would otherwise
+land on an empty home feed. This middleware redirects them to /onboard
+on any non-exempt path. Exempt paths bypass the DB query entirely so a
+sign-in flow or static asset doesn't trigger a Neon wake.
+"""
+
+import uuid
+from collections.abc import Awaitable, Callable
+
+from sqlmodel import Session
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+
+from app.db import engine as default_engine
+from app.models.user import TasteProfile
+
+# Paths the middleware never redirects. /onboard itself would otherwise
+# loop; /auth/* is required to sign in or out; /api/health* is hit by
+# Cloud Run probes; /static/* is plain files. We use prefix matching so
+# subroutes (e.g., /auth/verify) inherit the exemption.
+EXEMPT_PREFIXES: tuple[str, ...] = (
+    "/onboard",
+    "/auth/",
+    "/api/health",
+    "/static/",
+)
+
+
+class RequireTasteProfileMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        path = request.url.path
+        if any(path.startswith(p) for p in EXEMPT_PREFIXES):
+            return await call_next(request)
+
+        try:
+            raw_user_id = request.session.get("user_id")
+        except (AssertionError, AttributeError):
+            # SessionMiddleware isn't installed or the scope doesn't
+            # have a session — treat as anonymous and let the route
+            # handle auth itself.
+            return await call_next(request)
+
+        if not raw_user_id:
+            return await call_next(request)
+
+        try:
+            user_id = uuid.UUID(raw_user_id)
+        except (ValueError, TypeError):
+            return await call_next(request)
+
+        # Tests override app.state.engine to point at their in-memory
+        # SQLite; production uses the module-level Neon-bound engine.
+        active_engine = getattr(request.app.state, "engine", default_engine)
+        with Session(active_engine) as db:
+            profile = db.get(TasteProfile, user_id)
+
+        if profile is None:
+            return RedirectResponse("/onboard", status_code=302)
+        return await call_next(request)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,12 @@ def client_fixture(session: Session) -> Generator[TestClient, None, None]:
         yield session
 
     app.dependency_overrides[get_session] = get_session_override
+    # RequireTasteProfileMiddleware reads app.state.engine to query
+    # TasteProfile outside FastAPI's DI. Point it at the test engine so
+    # the middleware exercises real DB lookups against test data
+    # rather than the dev-default sqlite or production Neon.
+    original_engine = getattr(app.state, "engine", None)
+    app.state.engine = session.bind
     # base_url=https so SessionMiddleware's Secure cookie survives the
     # httpx cookie jar — without this, the cookie is set on the response
     # but stripped on the next request because Secure cookies don't ride
@@ -67,3 +73,5 @@ def client_fixture(session: Session) -> Generator[TestClient, None, None]:
     with TestClient(app, base_url="https://testserver") as client:
         yield client
     app.dependency_overrides.clear()
+    if original_engine is not None:
+        app.state.engine = original_engine

--- a/tests/onboard/test_redirect.py
+++ b/tests/onboard/test_redirect.py
@@ -1,0 +1,128 @@
+"""Tests for RequireTasteProfileMiddleware.
+
+Covers the Definition of Done items from #26:
+
+* an authenticated user without a TasteProfile is redirected from / to
+  /onboard
+* the same user is NOT redirected from /onboard, /auth/login, the
+  health endpoints, or /static/foo
+* an anonymous user is NOT redirected (route handles auth itself)
+* an authenticated user WITH a TasteProfile is NOT redirected
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.auth.tokens import generate_token, hash_token
+from app.models import FormLength, Genre, MagicLinkToken, TasteProfile, Tone, User
+
+
+def _sign_in(client: TestClient, session: Session, email: str) -> User:
+    """Drive /auth/verify to set a session cookie. Returns the User row
+    so the test can decide whether to give it a TasteProfile."""
+    raw = generate_token()
+    session.add(
+        MagicLinkToken(
+            email=email,
+            token_hash=hash_token(raw),
+            expires_at=datetime.now(UTC) + timedelta(minutes=15),
+        )
+    )
+    session.commit()
+    response = client.get(f"/auth/verify?token={raw}", follow_redirects=False)
+    assert response.status_code == 302
+    user = session.exec(
+        User.__table__.select().where(User.__table__.c.email == email)  # type: ignore[attr-defined]
+    ).first()
+    assert user is not None
+    return User(**user._asdict()) if not isinstance(user, User) else user
+
+
+def _attach_taste_profile(session: Session, user_id) -> None:
+    session.add(
+        TasteProfile(
+            user_id=user_id,
+            genres=[Genre.LITERARY.value],
+            tones=[Tone.CONTEMPLATIVE.value],
+            form_lengths=[FormLength.FLASH.value],
+        )
+    )
+    session.commit()
+
+
+def test_authenticated_user_without_profile_redirected_from_home(
+    client: TestClient, session: Session
+) -> None:
+    _sign_in(client, session, "newcomer@example.com")
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/onboard"
+
+
+def test_authenticated_user_with_profile_not_redirected(
+    client: TestClient, session: Session
+) -> None:
+    _sign_in(client, session, "returner@example.com")
+    user = session.exec(
+        User.__table__.select().where(User.__table__.c.email == "returner@example.com")  # type: ignore[attr-defined]
+    ).one()
+    _attach_taste_profile(session, user.id)
+
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 200
+
+
+def test_anonymous_user_not_redirected(client: TestClient) -> None:
+    """No session cookie → middleware passes through. The home route
+    is the public landing page, so anonymous gets 200."""
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 200
+
+
+def test_no_redirect_on_onboard_path(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "newcomer@example.com")
+    response = client.get("/onboard", follow_redirects=False)
+    # Without the exemption this would be 302 → /onboard (loop). With
+    # the exemption, the /onboard route runs and returns 200.
+    assert response.status_code == 200
+
+
+def test_no_redirect_on_auth_paths(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "newcomer@example.com")
+    response = client.get("/auth/login", follow_redirects=False)
+    assert response.status_code == 200
+
+
+def test_no_redirect_on_health_paths(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "newcomer@example.com")
+    response = client.get("/api/health", follow_redirects=False)
+    assert response.status_code == 200
+
+
+def test_no_redirect_on_static_paths(client: TestClient, session: Session) -> None:
+    _sign_in(client, session, "newcomer@example.com")
+    # A non-existent static file still goes through the StaticFiles
+    # mount; the middleware exempts the prefix so the StaticFiles 404
+    # is the response (not the /onboard redirect).
+    response = client.get("/static/no-such-file.css", follow_redirects=False)
+    assert response.status_code == 404
+    # Critically, it's NOT a redirect to /onboard.
+    assert response.headers.get("location") != "/onboard"
+
+
+def test_no_redirect_on_logout_endpoint(client: TestClient, session: Session) -> None:
+    """Authenticated user without profile clicks Log out. Middleware
+    must NOT intercept (/auth/* is exempt); the logout handler does its
+    own session.clear() then redirects to /."""
+    _sign_in(client, session, "newcomer@example.com")
+    response = client.post("/auth/logout", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+
+
+def test_anonymous_on_static_is_not_redirected(client: TestClient) -> None:
+    """Defensive: anonymous + exempt path should pass through cleanly."""
+    response = client.get("/api/health", follow_redirects=False)
+    assert response.status_code == 200


### PR DESCRIPTION
## Ticket
Closes #26 — Force onboarding redirect for users without taste profile
Project board: https://github.com/orgs/vibeacademy/projects/17

## Summary
Closes the auth → onboarding gate. A signed-in user without a `TasteProfile` would otherwise land on an empty home feed; this middleware redirects them to `/onboard` for any non-exempt path. Anonymous users and exempt paths (auth flow, the onboard form itself, health probes, static assets) pass through without a DB hit.

## Changes Made
- `app/onboard/middleware.py` — new `RequireTasteProfileMiddleware`. Order on the incoming request: exempt-prefix check first (returns early, no DB query); then session lookup; then UUID parse with graceful fallback; then a single PK-by-user-id SELECT against `TasteProfile`. Redirect only on the "authenticated + non-exempt + no profile" path.
- `app/main.py` — register the middleware **before** `SessionMiddleware` in code order so `SessionMiddleware` ends up outermost. Starlette wraps middlewares in stack order (last-added is outermost on the incoming request), so this arrangement gives the right execution sequence: `request → SessionMiddleware (populates session) → RequireTasteProfile (reads session, conditionally redirects) → ProxyHeaders → handler`. Also expose `app.state.engine = engine` so the middleware can query the right DB in production AND in tests.
- `tests/conftest.py` — `client_fixture` now also sets `app.state.engine = session.bind` so the middleware's lookup hits the test session's engine instead of the dev-default sqlite. Restored to the original value on fixture teardown.
- `tests/onboard/test_redirect.py` — 9 new tests covering the full DoD plus extras: logout endpoint exemption, anonymous-on-exempt-path pass-through, static-file 404 not redirected to /onboard.

## Security & ticket guardrails
- **Anonymous users NOT redirected** — middleware returns early when `request.session.get("user_id")` is empty/missing. Verified by `test_anonymous_user_not_redirected` and `test_anonymous_on_static_is_not_redirected`.
- **No DB query on exempt paths** — the exempt-prefix check is the first thing the middleware does; the DB session is only opened for authenticated + non-exempt requests.
- **No loop on POST /onboard** — `/onboard` is in `EXEMPT_PREFIXES`, so the redirect target is itself never gated.
- **Allowlist**: `/onboard`, `/auth/*` (covers `/auth/login`, `/auth/verify`, `/auth/logout`), `/api/health` (replaces the ticket's `/healthz` which doesn't exist on this stack — see PR #37 / GFE-reserved-path memory), `/static/*`.

## Out of scope (separate tickets)
- `/u/{display_name}` is NOT in the exemption list — a user without a taste profile visiting another author's profile gets redirected to onboard. Acceptable for v1 (one-time gate; once they fill it out, they can browse freely). Could be relaxed later if UX feedback suggests profiles should be browsable pre-onboarding.

## Testing
### Automated
- [x] `uv run pytest --cov=app` — **77/77 pass, 97% coverage** (up from 68/98%; new middleware at 100%)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues found in 26 source files

### Coverage of DoD bullets
- [x] Authenticated user without profile redirected from / → `test_authenticated_user_without_profile_redirected_from_home`
- [x] NOT redirected from /onboard, /auth/login, /api/health, /static/* → 4 separate tests
- [x] Anonymous user NOT redirected → `test_anonymous_user_not_redirected`
- [x] Authenticated user WITH profile NOT redirected → `test_authenticated_user_with_profile_not_redirected`

## Reviewer-friendly notes
- **Middleware order** in `app/main.py` is load-bearing. Starlette's stacking means `app.add_middleware()` calls are evaluated last-to-first on incoming requests. SessionMiddleware MUST come last in code order (= outermost = runs first on incoming) so `request.session` is populated before `RequireTasteProfileMiddleware` reads it.
- **Engine injection via `app.state.engine`**: middleware doesn't have FastAPI's dependency-override hook for `get_session`, so the engine reference is plumbed via `app.state`. Production reads the module-level `engine`; tests overwrite it with `session.bind` (the test-session's engine). Restored on fixture teardown.
- **Health path: `/api/health`, NOT `/healthz`**. The ticket body says `/healthz`; that path was renamed in #37 because Cloud Run's GFE intercepts the literal lowercase `/healthz` on `*.run.app` URLs. The allowlist follows the actual route shape.

## Checklist
- [x] All tests pass (77/77)
- [x] Code follows project standards
- [x] No linting warnings
- [x] mypy clean